### PR TITLE
Add volumeattachments resource handling permission in service account

### DIFF
--- a/deploy/charts/custom-scheduler-eks/templates/serviceaccount.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/serviceaccount.yaml
@@ -157,6 +157,7 @@ rules:
   - storage.k8s.io
   resources:
   - csinodes
+  - volumeattachments
   verbs:
   - get
   - list


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In kubernetes version 1.32, the scheduler has trouble to access `VolumeAttachment` with the service account which has no permission.

```text
I0324 06:16:52.991137       1 reflector.go:349] Listing and watching *v1.VolumeAttachment from k8s.io/client-go/informers/factory.go:160
W0324 06:16:53.000230       1 reflector.go:569] k8s.io/client-go/informers/factory.go:160: failed to list *v1.VolumeAttachment: volumeattachments.storage.k8s.io is forbidden: User "system:serviceaccount:kube-system:my-scheduler" cannot list resource "volumeattachments" in API group "storage.k8s.io" at the cluster scope
E0324 06:16:53.000258       1 reflector.go:166] "Unhandled Error" err="k8s.io/client-go/informers/factory.go:160: Failed to watch *v1.VolumeAttachment: failed to list *v1.VolumeAttachment: volumeattachments.storage.k8s.io is forbidden: User \"system:serviceaccount:kube-system:my-scheduler\" cannot list resource \"volumeattachments\" in API group \"storage.k8s.io\" at the cluster scope" logger="UnhandledError"
```

So, add `volumeattachments` resource permission in service account.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
