### PR TITLE
Modifications to values yaml file

### DIFF
--- a/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           - --v={{ .Values.logLevel }}
           securityContext:
             {{- toYaml .Values.podSecurityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ index .Values.image.tags .Values.eksVersion }}"
+          image: "{{ .Values.image.repository }}:{{ index .Values.image.tags (printf "%v" .Values.eksVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -15,16 +15,16 @@ image:
   repository: public.ecr.aws/eks-distro/kubernetes/kube-scheduler
   pullPolicy: IfNotPresent
   tags:
-    1.24: "v1.24.17-eks-1-24-latest"
-    1.25: "v1.25.16-eks-1-25-latest"
-    1.26: "v1.26.15-eks-1-26-latest"
-    1.27: "v1.27.16-eks-1-27-latest"
-    1.28: "v1.28.15-eks-1-28-latest"
-    1.29: "v1.29.14-eks-1-29-latest"
-    1.30: "v1.30.10-eks-1-30-latest"
-    1.31: "v1.31.6-eks-1-31-latest"
-    1.32: "v1.32.2-eks-1-32-latest"
-    1.33: "v1.33.1-eks-1-33-latest"
+    "1.24": "v1.24.17-eks-1-24-latest"
+    "1.25": "v1.25.16-eks-1-25-latest"
+    "1.26": "v1.26.15-eks-1-26-latest"
+    "1.27": "v1.27.16-eks-1-27-latest"
+    "1.28": "v1.28.15-eks-1-28-latest"
+    "1.29": "v1.29.14-eks-1-29-latest"
+    "1.30": "v1.30.10-eks-1-30-latest"
+    "1.31": "v1.31.6-eks-1-31-latest"
+    "1.32": "v1.32.2-eks-1-32-latest"
+    "1.33": "v1.33.1-eks-1-33-latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -123,7 +123,7 @@ affinity:
     requiredDuringSchedulingIgnoredDuringExecution:
     - labelSelector:
         matchLabels:
-          component: custom-scheduler-eks
+          app.kubernetes.io/name: custom-scheduler-eks
       topologyKey: kubernetes.io/hostname
 
 # Monitoring configuration

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -57,17 +57,17 @@ securityContext:
   runAsNonRoot: true
 
 
-resources:
+resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
   # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  requests:
-    cpu: '1'
-    memory: 1Gi
-  limits:
-    cpu: '2'
-    memory: 2Gi
+  #requests:
+  #  cpu: '1'
+  #  memory: 1Gi
+  #limits:
+  #  cpu: '1'
+  #  memory: 1Gi
 livenessProbe:
   httpGet:
     path: /healthz

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -137,10 +137,9 @@ monitoring:
     port: 10259
     # Target port for the metrics endpoint
     targetPort: 10259
-  
   serviceMonitor:
     # Enable ServiceMonitor resource
-    enabled: true 
+    enabled: true
     # Namespace where ServiceMonitor will be created
     #namespace: kube-prometheus-stack
     # Additional labels for the ServiceMonitor

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -15,16 +15,16 @@ image:
   repository: public.ecr.aws/eks-distro/kubernetes/kube-scheduler
   pullPolicy: IfNotPresent
   tags:
-    "1.24": "v1.24.17-eks-1-24-latest"
-    "1.25": "v1.25.16-eks-1-25-latest"
-    "1.26": "v1.26.15-eks-1-26-latest"
-    "1.27": "v1.27.16-eks-1-27-latest"
-    "1.28": "v1.28.15-eks-1-28-latest"
-    "1.29": "v1.29.14-eks-1-29-latest"
-    "1.30": "v1.30.10-eks-1-30-latest"
-    "1.31": "v1.31.6-eks-1-31-latest"
-    "1.32": "v1.32.2-eks-1-32-latest"
-    "1.33": "v1.33.1-eks-1-33-latest"
+    1.24: "v1.24.17-eks-1-24-latest"
+    1.25: "v1.25.16-eks-1-25-latest"
+    1.26: "v1.26.15-eks-1-26-latest"
+    1.27: "v1.27.16-eks-1-27-latest"
+    1.28: "v1.28.15-eks-1-28-latest"
+    1.29: "v1.29.14-eks-1-29-latest"
+    1.30: "v1.30.10-eks-1-30-latest"
+    1.31: "v1.31.6-eks-1-31-latest"
+    1.32: "v1.32.2-eks-1-32-latest"
+    1.33: "v1.33.1-eks-1-33-latest"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
*Description of changes:*

I made multiple small changes to be able to deploy the custom kube-scheduler without modifications. I overwrite the values.yaml for my specific deployment in only a few cases.

**1. Failing helm template**

When running `helm template .` from main, I get the following error:

> Error: template: custom-scheduler-eks/templates/deployment.yaml:49:52: executing "custom-scheduler-eks/templates/deployment.yaml" at <index .Values.image.tags .Values.eksVersion>: error calling index: value has type float64; should be string

**2. PodAntiAffinity has no valid matchLabels**

Instead of `component` we could use an existing matchLabel `app.kubernetes.io/name`.

**3. Resource requests should not be set**

It would be appreciated to not set resource requests in default values.yaml such that projects can decide to not set the cpu resource limits (as described in comment).

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
