### PR TITLE
feat(github-actions): create a chart releaser action to publish on changes to main

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -2,10 +2,9 @@ name: Release Helm Chart
 
 on:
   push:
-    tags:
-      - custom-scheduler-eks-*
+    branches:
+      - main
   workflow_dispatch:
-
 permissions:
   contents: write
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The chart isn't actually published anywhere, this resolves that by publishing to github pages and creating releases based on changes to main that affect the charts directory.

This does require gh-pages branch to exist and pages to be configured on the repo.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
