### PR TITLE
fix(chart): allow for watching/editing resourceslices

### DIFF
--- a/deploy/charts/custom-scheduler-eks/templates/serviceaccount.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/serviceaccount.yaml
@@ -132,6 +132,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - resource.k8s.io
+  resources:
+  - resourceslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - persistentvolumeclaims


### PR DESCRIPTION
*Issue #, if available:* #10

*Description of changes:*

Updates the RBAC in the chart to allow for read access to resourceslices. This doesn't update the other deploy manifests because those are targeting older k8s versions. This unblocks upgrading to 1.34

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
