### PR TITLE
Use default the cluster's ipFamily on metrics service

### DIFF
--- a/deploy/charts/custom-scheduler-eks/templates/metrics-service.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/metrics-service.yaml
@@ -11,9 +11,6 @@ metadata:
     {{- toYaml .Values.monitoring.service.annotations | nindent 4 }}
   {{- end }}
 spec:
-  ipFamilies:
-  - IPv4
-  ipFamilyPolicy: SingleStack
   ports:
   - name: metrics
     port: {{ .Values.monitoring.service.port | default 10259 }}


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*

We have a ipv6 only clusters that don't have ipv4 so we get an error like

> one or more objects failed to apply, reason: Service "custom-scheduler-eks-metrics" is invalid: spec.ipFamilies[0]: Invalid value: "IPv4": not configured on this cluster


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
