### PR TITLE
Fix chart bugs: image tag rendering, metrics namespace, SA/RBAC consistency

### DIFF
--- a/deploy/charts/custom-scheduler-eks/templates/metrics-service.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/metrics-service.yaml
@@ -6,7 +6,7 @@ metadata:
     app: {{ include "custom-scheduler-eks.name" . }}
     {{- include "custom-scheduler-eks.labels" . | nindent 4 }}
   name: {{ include "custom-scheduler-eks.fullname" . }}-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ .Values.nameSpace }}
   {{- if .Values.monitoring.service.annotations }}
   annotations:
     {{- toYaml .Values.monitoring.service.annotations | nindent 4 }}

--- a/deploy/charts/custom-scheduler-eks/templates/serviceaccount.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ include "custom-scheduler-eks.serviceAccountName" . }}
   namespace: {{ .Values.nameSpace }}
   labels:
     {{- include "custom-scheduler-eks.labels" . | nindent 4 }}
@@ -199,23 +199,23 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: custom-k8s-scheduler-as-kube-scheduler
+  name: {{ include "custom-scheduler-eks.fullname" . }}-as-kube-scheduler
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ include "custom-scheduler-eks.fullname" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ include "custom-scheduler-eks.serviceAccountName" . }}
   namespace: {{ .Values.nameSpace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: custom-k8s-scheduler-as-volume-scheduler
+  name: {{ include "custom-scheduler-eks.fullname" . }}-as-volume-scheduler
 subjects:
 - kind: ServiceAccount
-  name: {{ .Values.serviceAccount.name }}
+  name: {{ include "custom-scheduler-eks.serviceAccountName" . }}
   namespace: {{ .Values.nameSpace }}
 roleRef:
   kind: ClusterRole

--- a/deploy/charts/custom-scheduler-eks/templates/servicemonitor.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/servicemonitor.yaml
@@ -24,7 +24,7 @@ spec:
       insecureSkipVerify: {{ .Values.monitoring.serviceMonitor.insecureSkipVerify | default false }}
   namespaceSelector:
     matchNames:
-    - {{ .Release.Namespace }}
+    - {{ .Values.nameSpace }}
   selector:
     matchLabels:
       {{- include "custom-scheduler-eks.labels" . | nindent 6 }}

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -4,7 +4,7 @@
 
 replicaCount: 2
 nameSpace: kube-system
-eksVersion: 1.24
+eksVersion: "1.24"
 leaderElection:
   enabled: true
 


### PR DESCRIPTION
*Description of changes:*

- Quote eksVersion default so the image.tags lookup resolves (was a YAML float, produced an empty image tag)

- Place metrics Service and ServiceMonitor namespaceSelector in .Values.nameSpace so the Service gets endpoints and Prometheus scrapes the right namespace

- Use the serviceAccountName helper for the SA and ClusterRoleBinding subjects to avoid an empty SA name when serviceAccount.name is unset

- Template ClusterRoleBinding names to prevent cluster-wide collisions across multiple releases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
