### PR TITLE
Support full image.tag override

### DIFF
--- a/deploy/charts/custom-scheduler-eks/Chart.yaml
+++ b/deploy/charts/custom-scheduler-eks/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
@@ -46,7 +46,7 @@ spec:
           - --v={{ .Values.logLevel }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ index .Values.image.tags (printf "%s" .Values.eksVersion) }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (index .Values.image.tags (printf "%s" .Values.eksVersion)) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -14,6 +14,9 @@ schedulerName: custom-scheduler-eks
 image:
   repository: public.ecr.aws/eks-distro/kubernetes/kube-scheduler
   pullPolicy: IfNotPresent
+  # Full image tag override. When set, it is used directly and the
+  # eksVersion -> tags lookup below is ignored.
+  tag: ""
   tags:
     "1.24": "v1.24.17-eks-1-24-latest"
     "1.25": "v1.25.16-eks-1-25-latest"


### PR DESCRIPTION
*Description of changes:*

Add an optional image.tag value.
When set, it is used as the image tag directly; when empty, the existing eksVersion -> image.tags lookup is preserved.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
