### PR TITLE
Add topologySpreadConstraints support to deployment chart

### DIFF
--- a/deploy/charts/custom-scheduler-eks/Chart.yaml
+++ b/deploy/charts/custom-scheduler-eks/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
@@ -70,3 +70,7 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -129,6 +129,8 @@ affinity:
           app.kubernetes.io/name: custom-scheduler-eks
       topologyKey: kubernetes.io/hostname
 
+topologySpreadConstraints: []
+
 # Monitoring configuration
 monitoring:
   enabled: false


### PR DESCRIPTION
*Description of changes:*

Render an optional spec.topologySpreadConstraints block in the deployment template, gated on .Values.topologySpreadConstraints and placed after tolerations.
Defaults to an empty list so the block is omitted unless configured.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
