### PR TITLE
Make scheduler bind address configurable

### DIFF
--- a/deploy/charts/custom-scheduler-eks/Chart.yaml
+++ b/deploy/charts/custom-scheduler-eks/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.2.10
+version: 0.2.11
 
 
 

--- a/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: {{ .Chart.Name }}
           command:
           - /usr/local/bin/kube-scheduler
-          - --bind-address=0.0.0.0
+          - --bind-address={{ .Values.bindAddress }}
           - --config=/etc/kubernetes/custom-k8s-scheduler/custom-scheduler-eks-config.yaml
           - --v={{ .Values.logLevel }}
           securityContext:

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -11,6 +11,9 @@ leaderElection:
 logLevel: 5
 schedulerName: custom-scheduler-eks
 
+# Address the scheduler binds to. Use "0.0.0.0" for IPv4 or "::" for IPv6.
+bindAddress: "0.0.0.0"
+
 image:
   repository: public.ecr.aws/eks-distro/kubernetes/kube-scheduler
   pullPolicy: IfNotPresent


### PR DESCRIPTION
*Description of changes:*

Replace the hard-coded --bind-address=0.0.0.0 flag with a templated .Values.bindAddress, defaulting to "0.0.0.0".
Allows binding to IPv6 ("::") on dual-stack/IPv6 clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
