### PR TITLE
fix: quote --bind-address arg to support IPv6 bind address "::"

### DIFF
--- a/deploy/charts/custom-scheduler-eks/Chart.yaml
+++ b/deploy/charts/custom-scheduler-eks/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.2.11
+version: 0.2.12
 
 
 

--- a/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
+++ b/deploy/charts/custom-scheduler-eks/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
         - name: {{ .Chart.Name }}
           command:
           - /usr/local/bin/kube-scheduler
-          - --bind-address={{ .Values.bindAddress }}
+          - "--bind-address={{ .Values.bindAddress }}"
           - --config=/etc/kubernetes/custom-k8s-scheduler/custom-scheduler-eks-config.yaml
           - --v={{ .Values.logLevel }}
           securityContext:


### PR DESCRIPTION
*Description of changes:*

Setting bindAddress to "::" rendered the unquoted line `- --bind-address=::` in the container command.
YAML treats a trailing colon as a mapping-key indicator, so this parsed as an object instead of a string, causing the deploy to fail with:

    cannot unmarshal object into Go struct field
    Container.spec.template.spec.containers.command of type string

Quoting the argument forces it to render as a plain string, allowing IPv6 bind addresses to work.

Missed this in my previous commit, sorry!


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
