### PR TITLE
Update values.yaml with Image tag for EKS 1.36

### DIFF
--- a/deploy/charts/custom-scheduler-eks/Chart.yaml
+++ b/deploy/charts/custom-scheduler-eks/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 
-version: 0.2.12
+version: 0.2.13
 
 
 

--- a/deploy/charts/custom-scheduler-eks/values.yaml
+++ b/deploy/charts/custom-scheduler-eks/values.yaml
@@ -33,6 +33,7 @@ image:
     "1.33": "v1.33.1-eks-1-33-latest"
     "1.34": "v1.34.1-eks-1-34-10"
     "1.35": "v1.35.0-eks-1-35-5"
+    "1.36": "v1.36.2-eks-1-36-7"
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Change Summary: Update the container image tag in values.yaml to v1.36.2-eks-1-36-7 to align with Amazon EKS Kubernetes version 1.36.

Details:
    New Tag: v1.36.2-eks-1-36-7
    EKS Kubernetes Version: 1.36

Reason for Change: This update ensures compatibility with Amazon EKS Kubernetes version 1.36. The image tag v1.36.2-eks-1-36-7 corresponds to the EKS-optimized build for Kubernetes 1.36 

*Issue #, if available:* The scheduler pods was failing to run on EKS Cluster version 1.36  because of the missing tag - Error - `kubelet Failed to apply default image tag "public.ecr.aws/eks-distro/kubernetes/kube-scheduler:": couldn't parse image name "public.ecr.aws/eks-distro/kubernetes/kube-scheduler:": invalid reference format`

*Description of changes:* Added the tag for the 1.36 from this repo - https://gallery.ecr.aws/eks-distro/kubernetes/kube-scheduler


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
